### PR TITLE
Mac m1/m2 'terraform init' issue resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ IMPORTANT - Once the repo is create change the 600735812827.dkr.ecr.us-west-1.am
 ssh-keygen -f california-region-key-pair
 
 
+
+[NOTE] If you're using Apple Silicon chip (ie mac m1 or m2) then,
+Follow these 3 below commands before 'terraform init' command 
+
+1) brew install kreuzwerker/taps/m1-terraform-provider-helper
+2) m1-terraform-provider-helper activate
+3) m1-terraform-provider-helper install hashicorp/template -v v2.2.0
+
 terraform init 
 
 


### PR DESCRIPTION
while executing terraform init you might face the below error if you are working in a MAC with M1 or M2 chip in it,

Error: Incompatible provider version

│ Provider Terraform Registry 95 v2.2.0 does not have a │ package available for your current platform, darwin_arm64.


ISSUE RESOLVED !!!